### PR TITLE
fix: display error purl name empty add purl name is empty return array string

### DIFF
--- a/internal/parser/purl.go
+++ b/internal/parser/purl.go
@@ -13,6 +13,9 @@ func parsePurl(keywords []string, p string) []string {
 
 	var upstream string
 	purl, err := packageurl.FromString(p)
+	if purl.Name == "" {
+		return keywords
+	}
 	if err != nil {
 		log.Fatalf("Error parsing package url: %v", err)
 	}


### PR DESCRIPTION
fix - OSS - Jacked: Displays error parsing package URL: name is required