### PR TITLE
fix: --fail-criteria now supports equal or higher than fail-criteria severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ The available `formats` are:
 - `spdx-tag-value`: A tag-value formatted report conforming to the [SPDX 2.2 specification](https://spdx.github.io/spdx-spec/).
 - `spdx-json`: A JSON report conforming to the [SPDX 2.2 JSON Schema](https://github.com/spdx/spdx-spec/blob/v2.2/schemas/spdx-schema.json).format.
 - `spdx-xml`: A XML report conforming to the [SPDX 2.2 XML: Schema](https://github.com/mil-oss/spdx-xsd/blob/master/xml/xsd/spdx-xml-ref.xsd).format.
+
+## Gating on severity of vulnerabilities
+Gating on the severity of vulnerabilities refers to the practice of selectively allowing or disallowing certain actions or operations based on the severity level of a vulnerability. For example, in the context of software security, gating on severity can involve setting up rules or policies that restrict certain activities or operations (such as code changes, deployments, or releases) if the severity level of any identified vulnerabilities exceeds a certain threshold.
+
+You can have Jacked exit with an error if any vulnerabilities are reported equal or higher than the specified severity. This works perfectly using Jacked CI pipeline. To use this, use the --fail-criteria <severity> CLI flag.
+
+Example, here's how you could trigger a CI pipeline failure if any vulnerabilities are found in the image with a severity of "low" or higher:
+```
+jacked --fail-criteria low
+```
+
 ## Useful Commands and Flags 🚩
 ```
 jacked [command] [flag]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can have Jacked exit with an error if any vulnerabilities are reported equal
 
 Example, here's how you could trigger a CI pipeline failure if any vulnerabilities are found in the image with a severity of "low" or higher:
 ```
-jacked --fail-criteria low
+jacked <image> --fail-criteria low
 ```
 
 ## Useful Commands and Flags 🚩

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ var rootCmd = &cobra.Command{
 	Use:    "jacked [image]",
 	Args:   cobra.MaximumNArgs(1),
 	Short:  "Jacked Vulnerability Analyzer",
-	Long:   `Description: Jacked Vulnerability Analyzer`,
+	Long:   `Description: Jacked provides organizations with a more comprehensive look at their application to take calculated actions and create a better security approach. Its primary purpose is to scan vulnerabilities to implement subsequent risk mitigation measures.`,
 	PreRun: preRun,
 	Run:    run,
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -194,12 +194,36 @@ func selectOutputType(outputTypes string, cfg *config.Configuration, arguments *
 func failCriteria(scanresult model.ScanResult, severity *string) {
 	vulns := scanresult.Vulnerabilities
 
-	for _, vuln := range vulns {
-		if strings.EqualFold(vuln.CVSS.Severity, *severity) {
+	Severities := []string{
+		"unknown",
+		"negligible",
+		"low",
+		"medium",
+		"high",
+		"critical",
+	}
 
-			log.Printf("Package: %v | CVE: %v | Severity: %v", vuln.Package, vuln.CVE, vuln.CVSS.Severity)
-			log.Errorf("%v found on scan result:", *severity)
-			os.Exit(1)
+	index := -1
+	for i := 0; i < len(Severities); i++ {
+		if Severities[i] == "low" {
+			index = i
+			break
+		}
+	}
+	var newSeverities []string
+	if index != -1 {
+		newSeverities = Severities[index:]
+	}
+
+	for _, vuln := range vulns {
+		for _, newSeverity := range newSeverities {
+
+			if strings.EqualFold(vuln.CVSS.Severity, newSeverity) {
+
+				log.Errorf("\n\nFAILED: Found a vulnerability that is equal or higher than %v severity!", strings.ToUpper(*severity))
+				log.Printf("Package Reference: %v | CVE: %v | Severity: %v\n", vuln.Package, vuln.CVE, vuln.CVSS.Severity)
+				os.Exit(1)
+			}
 		}
 	}
 }


### PR DESCRIPTION
example output. fail-criteria is LOW which detects equal or higher than the severity.

FAILED: Found a vulnerability that is equal or higher than LOW severity!
Package Reference: busybox | CVE: CVE-2022-28391 | Severity: HIGH