### PR TITLE
Update golangci-lint timeout to 2 minutes

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -50,3 +50,4 @@ jobs:
           with:
             version: latest
             skip-pkg-cache: true
+            args: --timeout 2m


### PR DESCRIPTION
Add args --timeout 2m to ensure the workflow will have a cycle on our code properly to avoid small timeout runtime error.