### PR TITLE
feat: Generate jackedci.yaml file

### DIFF
--- a/cmd/arguments.go
+++ b/cmd/arguments.go
@@ -91,7 +91,7 @@ func init() {
 	rootCmd.Flags().StringVarP(arguments.RegistryToken, "registry-token", "", cfg.Registry.Token, "Access token for private registry access")
 
 	rootCmd.Flags().StringVarP(arguments.IgnorePackageNames, "ignore-package-names", "", "", "Specify package names to be whitelisted on the result")
-	rootCmd.Flags().StringVarP(arguments.IgnoreVulnCVEs, "ignore-vuln-cves", "", "", "Specify CVEs to be whitelisted on the result")
+	rootCmd.Flags().StringVarP(arguments.IgnoreCVEs, "ignore-cves", "", "", "Specify CVEs to be whitelisted on the result")
 	rootCmd.Flags().BoolVarP(arguments.SkipDbUpdate, "skip-db-update", "" ,false, "Skip Database Update on Scanning")
 	
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "")

--- a/cmd/arguments.go
+++ b/cmd/arguments.go
@@ -12,6 +12,7 @@ import (
 var (
 	arguments   = model.NewArguments()
 	cfg         config.Configuration
+	ciCfg       config.CIConfiguration
 	quiet       bool
 	license     bool
 	secrets     bool
@@ -52,6 +53,7 @@ func init() {
 
 	// Configuration set Flags Arguments
 	cfg.Load()
+	ciCfg.CILoad()
 
 	arguments.DisableSecretSearch = &cfg.SecretConfig.Disabled
 	arguments.SecretContentRegex = &cfg.SecretConfig.SecretRegex

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,34 +20,54 @@ var (
 func init() {
 	rootCmd.AddCommand(cfgCmd)
 
-	cfgCmd.Flags().BoolP("display", "d", false, "Display the content of the configuration file")
+	cfgCmd.Flags().BoolP("display", "d", false, "Display the content of the CI configuration file")
+	cfgCmd.Flags().BoolP("ci-display", "", false, "Display the content of the configuration file")
 	cfgCmd.Flags().BoolP("help", "h", false, "Help for configuration")
 	cfgCmd.Flags().BoolP("path", "p", false, "Display the path of the configuration file")
+	cfgCmd.Flags().BoolP("ci-path", "", false, "Display the path of the CI configuration file")
 	cfgCmd.Flags().BoolP("reset", "r", false, "Restore default configuration file")
+	cfgCmd.Flags().BoolP("ci-reset", "", false, "Restore default CI configuration file")
 }
 
 func cfgRun(c *cobra.Command, _ []string) {
-	yamlcfg, err := yaml.Marshal(&cfg)
+	configuration, err := yaml.Marshal(&cfg)
 	if err != nil {
 		log.Fatalf("Error marshalling config: %v", err)
 		os.Exit(0)
 	}
 
-	if c.Flags().Changed("display") {
-		log.Info(config.File)
-		log.Infof("%v", string(yamlcfg))
+	ciConfig, err := yaml.Marshal(&ciCfg)
+	if err != nil {
+		log.Fatalf("Error marshalling CI config: %v", err)
 		os.Exit(0)
 	}
 
+	if c.Flags().Changed("display") {
+		log.Info(config.File)
+		log.Infof("%v", string(configuration))
+		os.Exit(0)
+	}
+	if c.Flags().Changed("ci-display") {
+		log.Info(config.CIFile)
+		log.Infof("%v", string(ciConfig))
+		os.Exit(0)
+	}
 	if c.Flags().Changed("path") {
 		log.Info(config.File)
 		os.Exit(0)
 	}
-
+	if c.Flags().Changed("ci-path") {
+		log.Info(config.CIFile)
+		os.Exit(0)
+	}
 	if c.Flags().Changed("reset") {
 		var newCfg config.Configuration
 		newCfg.ResetDefault()
-	} else {
+	}
+	if c.Flags().Changed("ci-reset") {
+		var newCiCfg config.CIConfiguration
+		newCiCfg.CIResetDefault()
+	}else {
 		err := c.Help()
 		if err != nil {
 			log.Errorln(err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ func preRun(_ *cobra.Command, args []string) {
 		arguments.Quiet = &quiet
 		cfg.Output = *arguments.Output
 		cfg.LicenseFinder = license
-		cfg.Ignore.Package.Name = SplitInput(*arguments.IgnorePackageNames)
+		ciCfg.FailCriteria.Package.Name = SplitInput(*arguments.IgnorePackageNames)
 		ciCfg.FailCriteria.Vulnerability.CVE = SplitInput(*arguments.IgnoreCVEs)
 
 		if *arguments.Quiet {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,7 +126,9 @@ func SplitInput(input string) []string {
 			inputs = append(inputs, strings.ToLower(o))
 		}
 	} else {
-		inputs = append(inputs, strings.ToLower(input))
+		if len(input) > 0 {
+			inputs = append(inputs, strings.ToLower(input))
+		}
 	}
 	return inputs
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ func preRun(_ *cobra.Command, args []string) {
 		cfg.Output = *arguments.Output
 		cfg.LicenseFinder = license
 		cfg.Ignore.Package.Name = SplitInput(*arguments.IgnorePackageNames)
-		cfg.Ignore.Vulnerability.CVE = SplitInput(*arguments.IgnoreVulnCVEs)
+		ciCfg.FailCriteria.Vulnerability.CVE = SplitInput(*arguments.IgnoreCVEs)
 
 		if *arguments.Quiet {
 			logger.SetQuietMode()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ func run(c *cobra.Command, args []string) {
 	}
 
 	if ciMode {
-		ci.Analyze(arguments, &cfg)
+		ci.Analyze(arguments, &ciCfg)
 	}
 
 	// Check user output type is supported
@@ -98,7 +98,7 @@ func run(c *cobra.Command, args []string) {
 		log.Printf("Scanning SBOM JSON: %v", *arguments.SbomFile)
 	}
 
-	engine.Start(arguments, &cfg)
+	engine.Start(arguments, &cfg, &ciCfg)
 }
 
 // ValidateOutputArg checks if output types specified are valid

--- a/internal/config/ci-config.go
+++ b/internal/config/ci-config.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+)
+
+type CIConfiguration struct {
+	FailCriteria             FailCriteria             `yaml:"ignore"`
+}
+
+type FailCriteria struct {
+	Vulnerability Vulnerability `yaml:"vulnerability"`
+	Package       Package       `yaml:"package"`
+}
+
+var CIFile  = FileSetter("jackedci")
+
+// Indicate the default value for each configuration
+func (cfg *CIConfiguration) CISetDefault() *CIConfiguration {
+
+	DefaultIgnoreVulnerability := Vulnerability{
+		CVE:      []string{},
+		Severity: []string{},
+	}
+
+	DefaultIgnorePackage := Package{
+		Name:    []string{},
+		Type:    []string{},
+		Version: []string{},
+	}
+
+	DefaultFailCriteria := FailCriteria{
+		Vulnerability: DefaultIgnoreVulnerability,
+		Package:       DefaultIgnorePackage,
+	}
+
+	cfg.FailCriteria = DefaultFailCriteria
+
+	return cfg
+}
+
+// Generate the configuration file with default values
+func (cfg *CIConfiguration) CIGenerate() {
+	cfg.CISetDefault()
+	GenerateConfigFile(CIFile, cfg)
+}
+
+// Read the configuration file and parse it
+func (cfg *CIConfiguration) CILoad() *CIConfiguration {
+	if _, err := os.Stat(CIFile); err != nil {
+		cfg.CIGenerate()
+		cfg.CILoad()
+	} else {
+		LoadConfiguration(CIFile, cfg)
+	}
+	return cfg
+}
+
+// Update the current configuration file
+func (cfg *CIConfiguration) CIUpdate() {
+	UpdateConfiguration(CIFile)
+	cfg.CILoad()
+	log.Info("Done!")
+}
+
+// Resets the configuration to default values
+func (cfg *CIConfiguration) CIResetDefault() {
+	ResetDefaultConfiguration(CIFile)
+	cfg.CILoad()
+	log.Info("Done!")
+}

--- a/internal/config/config-utils.go
+++ b/internal/config/config-utils.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/carbonetes/jacked/internal/logger"
+
+	"gopkg.in/yaml.v2"
+)
+
+var log   = logger.GetLogger()
+
+type Vulnerability struct {
+	CVE      []string `yaml:"cve"`
+	Severity []string `yaml:"severity"`
+}
+
+type Package struct {
+	Name    []string `yaml:"name"`
+	Type    []string `yaml:"type"`
+	Version []string `yaml:"version"`
+}
+
+func FileSetter (filename string) string{
+	var(
+		configType = "yaml"
+		home, _    = os.UserHomeDir()
+	)
+
+	return home + string(os.PathSeparator) + "." + filename + "." + configType
+}
+
+func GenerateConfigFile (filename string , cfg interface{}){
+	err := os.MkdirAll(filepath.Dir(filename), 0700)
+	if err != nil {
+		log.Fatalf("Cannot create directory %v", err.Error())
+	}
+	out, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Fatalf("error encoding: %v", err)
+	}
+	defer out.Close()
+	enc := yaml.NewEncoder(out)
+
+	err = enc.Encode(cfg)
+	if err != nil {
+		log.Fatalf("error encoding: %v", err)
+	}
+}
+
+func LoadConfiguration(filename string, cfg interface{}) {
+	configFile, err := os.ReadFile(filename)
+	if err != nil {
+		log.Fatalf("Error reading configuration file: %v", err)
+	}
+	
+	err = yaml.Unmarshal(configFile, cfg)
+	if err != nil {
+		log.Fatalf("Error loading configurations: %v", err)
+	}
+}
+
+func UpdateConfiguration (filename string){
+	log.Info("Updating configuration...")
+	err := os.Remove(filename)
+	if err != nil {
+		log.Fatalf("Error deleting old configuration File: %v", err)
+	}
+}
+
+func ResetDefaultConfiguration (filename string){
+	log.Info("Resetting to default configurations...")
+	err := os.Remove(filename)
+	if err != nil {
+		log.Fatalf("Error deleting temp File: %v", err)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -21,7 +21,7 @@ import (
 var log = logger.GetLogger()
 
 // Start the scan engine with the given arguments and configurations
-func Start(arguments *model.Arguments, cfg *config.Configuration) {
+func Start(arguments *model.Arguments, cfg *config.Configuration, ciCfg *config.CIConfiguration) {
 
 	var (
 		sbom            *dm.SBOM
@@ -52,7 +52,7 @@ func Start(arguments *model.Arguments, cfg *config.Configuration) {
 	}
 	// Run all parsers and filters for packages
 
-	diggity.Filter(sbom.Packages, &cfg.Ignore.Package)
+	diggity.Filter(sbom.Packages, &ciCfg.FailCriteria.Package)
 	if cfg.LicenseFinder {
 		diggity.GetLicense(sbom.Packages, licenses)
 	}
@@ -68,7 +68,7 @@ func Start(arguments *model.Arguments, cfg *config.Configuration) {
 		log.Errorf("\nError Fetch Database: %v", err)
 	}
 
-	db.Filter(&vulnerabilities, &cfg.Ignore.Vulnerability)
+	db.Filter(&vulnerabilities,  &ciCfg.FailCriteria.Vulnerability)
 
 	// Begin matching vulnerabilities for each package
 	analysis.WG.Add(totalPackages)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -21,7 +21,7 @@ import (
 var log = logger.GetLogger()
 
 // Start the scan engine with the given arguments and configurations
-func Start(arguments *model.Arguments, cfg *config.Configuration, ciCfg *config.CIConfiguration) {
+func Start(arguments *model.Arguments, cfg *config.Configuration) {
 
 	var (
 		sbom            *dm.SBOM
@@ -52,7 +52,7 @@ func Start(arguments *model.Arguments, cfg *config.Configuration, ciCfg *config.
 	}
 	// Run all parsers and filters for packages
 
-	diggity.Filter(sbom.Packages, &ciCfg.FailCriteria.Package)
+	diggity.Filter(sbom.Packages, &cfg.Ignore.Package)
 	if cfg.LicenseFinder {
 		diggity.GetLicense(sbom.Packages, licenses)
 	}
@@ -68,7 +68,7 @@ func Start(arguments *model.Arguments, cfg *config.Configuration, ciCfg *config.
 		log.Errorf("\nError Fetch Database: %v", err)
 	}
 
-	db.Filter(&vulnerabilities,  &ciCfg.FailCriteria.Vulnerability)
+	db.Filter(&vulnerabilities,  &cfg.Ignore.Vulnerability)
 
 	// Begin matching vulnerabilities for each package
 	analysis.WG.Add(totalPackages)

--- a/pkg/core/ci/ci.go
+++ b/pkg/core/ci/ci.go
@@ -10,10 +10,10 @@ import (
 	dm "github.com/carbonetes/diggity/pkg/model"
 	diggity "github.com/carbonetes/diggity/pkg/scanner"
 	"github.com/carbonetes/jacked/internal/config"
-	"github.com/carbonetes/jacked/internal/logger"
 	"github.com/carbonetes/jacked/internal/db"
-	bomUtil "github.com/carbonetes/jacked/internal/sbom"
+	"github.com/carbonetes/jacked/internal/logger"
 	save "github.com/carbonetes/jacked/internal/output/save"
+	bomUtil "github.com/carbonetes/jacked/internal/sbom"
 	jacked "github.com/carbonetes/jacked/pkg/core/analysis"
 	"github.com/carbonetes/jacked/pkg/core/ci/assessment"
 	filter "github.com/carbonetes/jacked/pkg/core/ci/filter"
@@ -62,7 +62,7 @@ func Analyze(args *model.Arguments, ciCfg *config.CIConfiguration) {
 	} else {
 		log.Fatalf("No valid scan target specified!")
 	}
-	log.Println("\nGenerating CDX BOM...\n")
+	log.Println("\nGenerating CDX BOM...")
 	sbom, _ := diggity.Scan(diggityArgs)
 
 	bomUtil.Filter(sbom.Packages, &ciCfg.FailCriteria.Package)
@@ -75,7 +75,7 @@ func Analyze(args *model.Arguments, ciCfg *config.CIConfiguration) {
 
 	outputText += "Generated CDX BOM\n\n" + table.CDXBomTable(cdx)
 
-	log.Println("\nAnalyzing CDX BOM...\n")
+	log.Println("\nAnalyzing CDX BOM...")
 	jacked.AnalyzeCDX(cdx)
 	
 	filter.IgnoreVuln(cdx.Vulnerabilities, &ciCfg.FailCriteria.Vulnerability)
@@ -97,7 +97,7 @@ func Analyze(args *model.Arguments, ciCfg *config.CIConfiguration) {
 	}
 
 	log.Println("\nExecuting CI Assessment...")
-	log.Println("\nAssessment Result:\n")
+	log.Println("\nAssessment Result:")
 	outputText += "\n\nAssessment Result:\n"
 	if len(*cdx.Vulnerabilities) == 0 {
 		message := fmt.Sprintf("\nPassed: %5v found components\n", len(*cdx.Components))

--- a/pkg/core/ci/ci.go
+++ b/pkg/core/ci/ci.go
@@ -27,7 +27,7 @@ var (
 	defaultCriteria string = "LOW"
 )
 
-func Analyze(args *model.Arguments, cfg *config.Configuration) {
+func Analyze(args *model.Arguments, ciCfg *config.CIConfiguration) {
 	var outputText string
 	// Check database for any updates
     db.DBCheck(*args.SkipDbUpdate)
@@ -65,7 +65,7 @@ func Analyze(args *model.Arguments, cfg *config.Configuration) {
 	log.Println("\nGenerating CDX BOM...\n")
 	sbom, _ := diggity.Scan(diggityArgs)
 
-	bomUtil.Filter(sbom.Packages, &cfg.Ignore.Package)
+	bomUtil.Filter(sbom.Packages, &ciCfg.FailCriteria.Package)
 
 	if sbom.Packages == nil {
 		log.Error("No package found to analyze!")
@@ -78,7 +78,7 @@ func Analyze(args *model.Arguments, cfg *config.Configuration) {
 	log.Println("\nAnalyzing CDX BOM...\n")
 	jacked.AnalyzeCDX(cdx)
 	
-	filter.IgnoreVuln(cdx.Vulnerabilities, &cfg.Ignore.Vulnerability)
+	filter.IgnoreVuln(cdx.Vulnerabilities, &ciCfg.FailCriteria.Vulnerability)
 	if len(*cdx.Vulnerabilities) == 0 {
 		fmt.Println("No vulnerabilities found!")
 		outputText += "\nNo vulnerabilities found! \n"
@@ -92,7 +92,7 @@ func Analyze(args *model.Arguments, cfg *config.Configuration) {
 
 	log.Println("\nShowing Whitelist...\n")
 	outputText += "\n\nWhitelist / Ignore List\n"
-	outputText += "\n" + table.WhitelistTable(&cfg.Ignore)
+	outputText += "\n" + table.WhitelistTable(&ciCfg.FailCriteria)
 
 	log.Println("\nExecuting CI Assessment...")
 

--- a/pkg/core/ci/ci.go
+++ b/pkg/core/ci/ci.go
@@ -90,9 +90,9 @@ func Analyze(args *model.Arguments, ciCfg *config.CIConfiguration) {
 	outputText += "\n" + stats
 	log.Println(stats)
 
-	log.Println("\nShowing Whitelist...\n")
-	outputText += "\n\nWhitelist / Ignore List\n"
-	outputText += "\n" + table.WhitelistTable(&ciCfg.FailCriteria)
+	log.Println("\nShowing Ignore List...\n")
+	outputText += "\n\nIgnore List\n"
+	outputText += "\n" + table.IgnoreListTable(&ciCfg.FailCriteria)
 
 	log.Println("\nExecuting CI Assessment...")
 

--- a/pkg/core/ci/ci.go
+++ b/pkg/core/ci/ci.go
@@ -90,12 +90,13 @@ func Analyze(args *model.Arguments, ciCfg *config.CIConfiguration) {
 	outputText += "\n" + stats
 	log.Println(stats)
 
-	log.Println("\nShowing Ignore List...\n")
-	outputText += "\n\nIgnore List\n"
-	outputText += "\n" + table.IgnoreListTable(&ciCfg.FailCriteria)
+	if !ignoreListIsEmpty(&ciCfg.FailCriteria){
+		log.Println("\nShowing Ignore List...\n")
+		outputText += "\n\nIgnore List\n"
+		outputText += "\n" + table.IgnoreListTable(&ciCfg.FailCriteria)
+	}
 
 	log.Println("\nExecuting CI Assessment...")
-
 	log.Println("\nAssessment Result:\n")
 	outputText += "\n\nAssessment Result:\n"
 	if len(*cdx.Vulnerabilities) == 0 {
@@ -135,4 +136,21 @@ func saveOutputFile(args *model.Arguments, outputText string){
 		// we can use the *args.Output for the second args on the parameter, for now it only supports table/txt output
 		save.SaveOutputAsFile(*args.OutputFile,"table", outputText )
 	}
+}
+
+func ignoreListIsEmpty(ciCfg *config.FailCriteria) bool{
+	 var ignoreList = []bool{
+						len(ciCfg.Vulnerability.CVE) == 0,
+						len(ciCfg.Vulnerability.Severity) == 0,
+						len(ciCfg.Package.Name) == 0,
+						len(ciCfg.Package.Type) == 0,
+						len(ciCfg.Package.Version) == 0,
+					   } 
+	
+    for _, empty := range ignoreList{
+		if !empty {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/core/ci/table/ignore-list.go
+++ b/pkg/core/ci/table/ignore-list.go
@@ -7,15 +7,15 @@ import (
 	"github.com/carbonetes/jacked/internal/config"
 )
 
-func WhitelistTable (ignore *config.FailCriteria) string {
+func IgnoreListTable (ignore *config.FailCriteria) string {
 	table := simpleTable.New()
-	whitelistHeader(table)
-	whitelistRows(ignore,table)
+	ignoreListHeader(table)
+	ignoreListRows(ignore,table)
 	fmt.Println(table.String())
 	return table.String()
 }
 
-func whitelistHeader(table *simpleTable.Table) {
+func ignoreListHeader(table *simpleTable.Table) {
 	table.Header = &simpleTable.Header{
 		Cells: []*simpleTable.Cell{
 			{Align: simpleTable.AlignCenter, Text: "Ignore"},
@@ -24,7 +24,7 @@ func whitelistHeader(table *simpleTable.Table) {
 	}
 }
 
-func whitelistRows(ignore *config.FailCriteria,table *simpleTable.Table) {
+func ignoreListRows(ignore *config.FailCriteria,table *simpleTable.Table) {
 	const arraySize = 5
     ignoreLabels := [arraySize]string{"CVE", "Severity", "Name", "Type", "Version"}
 	ignoreList := [arraySize]string{strings.Join(ignore.Vulnerability.CVE,","), strings.Join(ignore.Vulnerability.Severity,","), strings.Join(ignore.Package.Name,","), strings.Join(ignore.Package.Type,","), strings.Join(ignore.Package.Version,",")}

--- a/pkg/core/ci/table/whitelist.go
+++ b/pkg/core/ci/table/whitelist.go
@@ -7,7 +7,7 @@ import (
 	"github.com/carbonetes/jacked/internal/config"
 )
 
-func WhitelistTable (ignore *config.Ignore) string {
+func WhitelistTable (ignore *config.FailCriteria) string {
 	table := simpleTable.New()
 	whitelistHeader(table)
 	whitelistRows(ignore,table)
@@ -24,7 +24,7 @@ func whitelistHeader(table *simpleTable.Table) {
 	}
 }
 
-func whitelistRows(ignore *config.Ignore,table *simpleTable.Table) {
+func whitelistRows(ignore *config.FailCriteria,table *simpleTable.Table) {
 	const arraySize = 5
     ignoreLabels := [arraySize]string{"CVE", "Severity", "Name", "Type", "Version"}
 	ignoreList := [arraySize]string{strings.Join(ignore.Vulnerability.CVE,","), strings.Join(ignore.Vulnerability.Severity,","), strings.Join(ignore.Package.Name,","), strings.Join(ignore.Package.Type,","), strings.Join(ignore.Package.Version,",")}

--- a/pkg/core/model/arguments.go
+++ b/pkg/core/model/arguments.go
@@ -20,6 +20,6 @@ type Arguments struct {
 	ExcludedFilenames   *[]string
 	FailCriteria        *string
 	IgnorePackageNames  *string
-	IgnoreVulnCVEs      *string
+	IgnoreCVEs          *string
 	SkipDbUpdate        *bool
 }

--- a/pkg/core/model/arguments_init.go
+++ b/pkg/core/model/arguments_init.go
@@ -20,7 +20,7 @@ func NewArguments() *Arguments {
 		ExcludedFilenames:   &[]string{},
 		FailCriteria:        new(string),
 		IgnorePackageNames:  new(string),
-		IgnoreVulnCVEs:      new(string),
+		IgnoreCVEs:          new(string),
 		SkipDbUpdate:        new(bool),
 	}
 }

--- a/test/configuration_test.go
+++ b/test/configuration_test.go
@@ -13,7 +13,7 @@ func TestConfiguration(t *testing.T) {
 
 	t.Log("Generating test configuration")
 
-	config.Filename = "jacked-test"
+	config.File = "jacked-test"
 
 	testConfig.Generate()
 


### PR DESCRIPTION
1.  Generate jackedci.yaml file.
2.  Flag renamed from --ignore-vuln-cves to --ignore-cves and changed the target to jackedci.yaml.
3.  Changed the target of --ignore-package-names to jackedci.yaml.
4.  File and function renamed from whitelist to ignore list.
5.  Ignore list table is hidden when the ignore list is empty on CI Mode